### PR TITLE
feat: Add shadcn-ui MCP server with dedicated GitHub token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Secrets
 secrets.yaml
-secrets.enc.yaml
 
 # Personal Config Files
 user-config.nix

--- a/home/default.nix
+++ b/home/default.nix
@@ -9,6 +9,7 @@ in
     (import ./programs.nix { inherit config pkgs lib; })
     ./platforms.nix
     ./hosts/default.nix
+    ./mcp-servers.nix
   ];
 
   # sops-nix configuration
@@ -24,6 +25,9 @@ in
       };
       github_token = {
         key = "github/token";
+      };
+      github_mcp_token = {
+        key = "github/mcp_token";
       };
     };
   };

--- a/home/mcp-servers.nix
+++ b/home/mcp-servers.nix
@@ -1,0 +1,165 @@
+{ config, pkgs, lib, ... }:
+
+let
+  # Platform detection
+  isLinux = pkgs.stdenv.isLinux;
+  isDarwin = pkgs.stdenv.isDarwin;
+in
+{
+  # Install shadcn-ui-mcp-server via npm
+  home.activation.shadcnUiMcpServer = config.lib.dag.entryAfter ["writeBoundary"] ''
+    set -e  # Exit on any error
+    
+    echo "🔧 Setting up shadcn-ui-mcp-server..."
+    
+    # Create npm global directory in home
+    export NPM_CONFIG_PREFIX="$HOME/.npm-global"
+    mkdir -p "$HOME/.npm-global"
+    
+    # Add Node.js and npm to PATH for this activation script
+    export PATH="${pkgs.nodejs_22}/bin:${pkgs.nodePackages.npm}/bin:$PATH"
+    
+    echo "✅ node found: $(which node)"
+    echo "✅ npm found: $(which npm)"
+    echo "📍 NPM prefix: $NPM_CONFIG_PREFIX"
+    
+    # Install or update shadcn-ui-mcp-server
+    if ! npm list -g @jpisnice/shadcn-ui-mcp-server >/dev/null 2>&1; then
+      echo "📦 Installing shadcn-ui-mcp-server..."
+      npm install -g @jpisnice/shadcn-ui-mcp-server || {
+        echo "❌ Failed to install shadcn-ui-mcp-server"
+        exit 1
+      }
+      echo "✅ shadcn-ui-mcp-server installed successfully!"
+    else
+      echo "🔄 shadcn-ui-mcp-server already installed, checking for updates..."
+      npm update -g @jpisnice/shadcn-ui-mcp-server || {
+        echo "⚠️  Failed to update shadcn-ui-mcp-server, but continuing..."
+      }
+    fi
+  '';
+
+  # Create systemd user service for Linux/WSL
+  systemd.user.services.shadcn-ui-mcp-server = lib.mkIf isLinux {
+    Unit = {
+      Description = "shadcn/ui MCP Server";
+      Documentation = "https://github.com/Jpisnice/shadcn-ui-mcp-server";
+    };
+
+    Service = {
+      Type = "simple";
+      # Use npx to run the server
+      ExecStart = "${pkgs.nodejs_22}/bin/npx @jpisnice/shadcn-ui-mcp-server";
+      
+      # Set up environment with GitHub token from sops
+      Environment = [
+        "NPM_CONFIG_PREFIX=%h/.npm-global"
+        "PATH=${pkgs.nodejs_22}/bin:%h/.npm-global/bin:/usr/bin:/bin"
+      ];
+      
+      # Load GitHub token from sops secret if available
+      ExecStartPre = "${pkgs.writeShellScript "setup-github-token" ''
+        if [ -f "${config.sops.secrets.github_mcp_token.path}" ]; then
+          echo "GITHUB_PERSONAL_ACCESS_TOKEN=$(cat ${config.sops.secrets.github_mcp_token.path})" > %t/shadcn-ui-mcp-server.env
+        else
+          echo "# No GitHub MCP token found" > %t/shadcn-ui-mcp-server.env
+        fi
+      ''}";
+      
+      EnvironmentFile = "-%t/shadcn-ui-mcp-server.env";
+      
+      # Restart on failure
+      Restart = "on-failure";
+      RestartSec = "5s";
+      
+      # Security hardening
+      PrivateTmp = true;
+      ProtectSystem = "strict";
+      ProtectHome = "read-only";
+      ReadWritePaths = "%h/.npm-global";
+      NoNewPrivileges = true;
+    };
+
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+  };
+
+  # For macOS, create a launchd configuration
+  launchd.agents.shadcn-ui-mcp-server = lib.mkIf isDarwin {
+    enable = true;
+    config = {
+      Label = "com.github.jpisnice.shadcn-ui-mcp-server";
+      ProgramArguments = [
+        "${pkgs.nodejs_22}/bin/npx"
+        "@jpisnice/shadcn-ui-mcp-server"
+      ];
+      
+      # Set up environment
+      EnvironmentVariables = {
+        NPM_CONFIG_PREFIX = "%h/.npm-global";
+        PATH = "${pkgs.nodejs_22}/bin:%h/.npm-global/bin:/usr/bin:/bin";
+        # Note: For macOS, we'll need to handle the GitHub token differently
+        # as launchd doesn't support reading from files directly
+      };
+      
+      # Run on demand
+      RunAtLoad = false;
+      KeepAlive = false;
+      
+      # Logging
+      StandardOutPath = "%h/Library/Logs/shadcn-ui-mcp-server.log";
+      StandardErrorPath = "%h/Library/Logs/shadcn-ui-mcp-server.error.log";
+    };
+  };
+
+  # Create a wrapper script that can be used to start the MCP server with the GitHub token
+  home.packages = [
+    (pkgs.writeShellScriptBin "shadcn-ui-mcp-server" ''
+      # Load GitHub token from sops if available
+      if [ -f "${config.sops.secrets.github_mcp_token.path}" ]; then
+        export GITHUB_PERSONAL_ACCESS_TOKEN="$(cat ${config.sops.secrets.github_mcp_token.path})"
+        echo "✅ Using GitHub MCP token from sops"
+      else
+        echo "ℹ️  No GitHub MCP token found, running with default rate limits"
+      fi
+      
+      # Run the MCP server
+      exec ${pkgs.nodejs_22}/bin/npx @jpisnice/shadcn-ui-mcp-server "$@"
+    '')
+  ];
+
+  # Add information about the MCP server to the user's shell
+  programs.fish.shellInit = lib.mkIf config.programs.fish.enable ''
+    # shadcn-ui-mcp-server info
+    function mcp-shadcn-status
+      if command -v systemctl &> /dev/null
+        systemctl --user status shadcn-ui-mcp-server
+      else if test (uname) = "Darwin"
+        launchctl list | grep shadcn-ui-mcp-server
+      else
+        echo "MCP server status not available on this platform"
+      end
+    end
+    
+    function mcp-shadcn-start
+      if command -v systemctl &> /dev/null
+        systemctl --user start shadcn-ui-mcp-server
+      else if test (uname) = "Darwin"
+        launchctl load ~/Library/LaunchAgents/com.github.jpisnice.shadcn-ui-mcp-server.plist
+      else
+        shadcn-ui-mcp-server
+      end
+    end
+    
+    function mcp-shadcn-stop
+      if command -v systemctl &> /dev/null
+        systemctl --user stop shadcn-ui-mcp-server
+      else if test (uname) = "Darwin"
+        launchctl unload ~/Library/LaunchAgents/com.github.jpisnice.shadcn-ui-mcp-server.plist
+      else
+        echo "Use Ctrl+C to stop the MCP server"
+      end
+    end
+  '';
+}

--- a/home/secrets/secrets.enc.yaml
+++ b/home/secrets/secrets.enc.yaml
@@ -1,24 +1,20 @@
 github:
-    name: ENC[AES256_GCM,data:hS2iupX40vq9NbvxzOcH9A==,iv:tAuaXgXfkCHHYwlOprtF+a6J9KxPZy4Izqlcww3jFHw=,tag:RmJVJVyt9o24vf+VtNBdiQ==,type:str]
-    email: ENC[AES256_GCM,data:n1v/j43ngP1gllnZxxfULsmW7w==,iv:P1xbuXdv293EgpkRA1FaPc/hU9St/7R0WCvWFuTdKzM=,tag:amRLgLaRSATCPXSwgy4sWA==,type:str]
-    token: ENC[AES256_GCM,data:dt09m+/ySGie3tt08nYsFkviDy413/tfz60tcx65/gMcY+4orZoP9A==,iv:ZehhcDo9RHWsrVFSKXXBPpAy8aW+KdexORIs29LcJRA=,tag:flW/fquUsFRytShJZKVVhg==,type:str]
+    name: ENC[AES256_GCM,data:tOAXgU14KJKE6svV2vF8GA==,iv:96xVlwHLMVfKmdntIECdzJPMZJEDvBUxsXVVI1ZyTV0=,tag:uPYRphIFVL4GKn4ZPKtpqg==,type:str]
+    email: ENC[AES256_GCM,data:VxbJJAYaNEHej6goceeo/qZsRA==,iv:JGO/4nf0m7ee5dqY8OwMjVYNVvl9ycN2mnOwME5WV/Y=,tag:l1Xvql+YrgzufuMrd6mlGQ==,type:str]
+    token: ENC[AES256_GCM,data:NxLapXFv968dUYc/bUfvoLCUn+A5aUnTX4Z9Kxn/1CPVUdGBsBuv9w==,iv:GEpjZKfOWJE9UkCgXSK6xWqiS95mSYGDYJ5+TQJJ518=,tag:+cjLYbBI8ZE/fBxBbHX3Wg==,type:str]
+    mcp_token: ENC[AES256_GCM,data:K6vw7O/B2qHTE5BBSkayTKXsXpMAzMcYZcGZOom8tzFapOHqC9oznQ==,iv:DYZa0mYjC5jFeyNKbASff+4xmMxGOgZ0nd7j4x8Oqnk=,tag:w4XdzhSXaPLBRKRSK+lnAQ==,type:str]
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv: []
-    hc_vault: []
     age:
-        - recipient: age14g9lmn2jueruw4a3wr23vdrl9pzljrd088kse3nh0pxh060j7uhsuufl7x
+        - recipient: age1alqvt59jud8ls6p0ereyhdz4h4uqmv66m2hdkfg4pazm20vucufqqzkq4y
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5VFUrWFUzb29HMWlRRSsw
-            Um9zdG1yN0lyOXJUaE9wZDJpOFBJL3ZjRVgwCnVRcGw3WFNPMGRGRlRkR3ZDTUdV
-            RWdhSm1yTnUzRjVXQlNMMzZFRTZaYjgKLS0tIFdWbUV4TE5jV3BQSEU1T1RmMzNJ
-            NXBpbXpXK2RxN1NrdllXY3QzZGxsY1kKDd1EsaSADezDszw4rYheb2oxVIY4ed5K
-            GmGv6wbsiyfC3lgGBtiYGRnkcZqvokz4VeGNDKLfN1Xtp7bW1nIFTw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiUnlSOGsxVzNSTVZ5VEZD
+            bUpEVUJEVXB6dDBXVWx6dDYrdDJyU0VsaEJRClBOWXRSTWRoRW13ZVF2dEJ6aFdY
+            WFhsKzJuZnJueTkvZVFKRWJ6SVdmaGsKLS0tIENGR2JnQ2p1a3V4TUtnU0tJOFI5
+            alM2b2tKL0d0eDFxd0hha0xtb3VIVzgK2LtUpwePVlancszyxf3Ua3e3YQ39rZmk
+            tjNQ5IJQNxjOi9+XK/YH5hyjkAZ+cSS8qsW8t/J7C6sc5IWnZ0SCGA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-06-21T00:42:45Z"
-    mac: ENC[AES256_GCM,data:rndvXOeHBXVIoYBjmbn5c07faXCvC+O/hQSljjUVzMeWRkw7K3aqg2zuO8VdQ++YxLa46rTDJF/h+h5lt1NbMyl4PtUambWPwIVkVxsjqEttxTHRocq0Qwq9kreOq4JjHQqJ4k2ngShgEfnHLQslXwButrBLPPsBJbTCz4I3peA=,iv:K4jFwmcxtPkSCkGBUN11PEqImOTWNRN0sg4lBEFNQxk=,tag:vKnXBqLJb8yNDsaBaLLQjw==,type:str]
-    pgp: []
+    lastmodified: "2025-07-22T17:39:36Z"
+    mac: ENC[AES256_GCM,data:FQePy4ROwSrdcW00KwOy2Ha5Yex7KF+jqCToo3xqA8sR4ipQO3wTEwfUEuieGZ7prhGFoLZqmUSltMDoLpAEJva/999OqPOKUEW40C87L/Oi3To3k493F2GK75Kqxyyy8pmn5vyvaJzRfsqos8zOq2f6piVrmqein7PLd64HglQ=,iv:GeC4CgqrHNI31cCDJceCuaZCEeWlXM8POPRARgrvUAg=,tag:r4XrZxPfRgM8S04pLIKIhQ==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.9.2
+    version: 3.10.2


### PR DESCRIPTION
- Create new mcp-servers.nix module for MCP server management
- Configure shadcn-ui-mcp-server with systemd service (Linux/WSL)
- Add launchd agent support for macOS
- Use separate low-scoped GitHub token (github_mcp_token) for MCP
- Update sops secrets configuration to include new MCP token
- Fix .gitignore to properly track encrypted secrets file
- Add fish shell helper functions for MCP server management: `mcp-shadcn-status`, `mcp-shadcn-start`, `mcp-shadcn-stop`

The MCP server provides AI assistants with access to shadcn/ui v4 components, blocks, demos, and metadata. Using a dedicated token with minimal scopes improves security isolation.

🤖 Generated with [Claude Code](https://claude.ai/code)