### PR TITLE
feat: Add MCP server setup script and improve mcp-servers.nix

### DIFF
--- a/.mcp.json.template
+++ b/.mcp.json.template
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "shadcn-ui-mcp-server": {
+      "type": "stdio",
+      "command": "/home/kourtni/.nix-profile/bin/shadcn-ui-mcp-server",
+      "args": [],
+      "env": {}
+    }
+  }
+}

--- a/.mcp.json.template
+++ b/.mcp.json.template
@@ -2,7 +2,7 @@
   "mcpServers": {
     "shadcn-ui-mcp-server": {
       "type": "stdio",
-      "command": "/home/kourtni/.nix-profile/bin/shadcn-ui-mcp-server",
+      "command": "__HOME__/.nix-profile/bin/shadcn-ui-mcp-server",
       "args": [],
       "env": {}
     }

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Script to set up MCP servers in a Claude Code project
+
+# Check if we're in a git repository or project directory
+if [ ! -d ".git" ] && [ ! -f "package.json" ] && [ ! -f "Cargo.toml" ] && [ ! -f "flake.nix" ]; then
+    echo "Warning: This doesn't appear to be a project directory."
+    read -p "Continue anyway? (y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+# Check if .mcp.json already exists
+if [ -f ".mcp.json" ]; then
+    echo "Error: .mcp.json already exists in this directory."
+    echo "Remove it first if you want to set up MCP servers again."
+    exit 1
+fi
+
+# Copy the template
+cp ~/dotfiles/.mcp.json.template .mcp.json
+
+echo "✅ MCP servers configured successfully!"
+echo "The following MCP servers are now available in this project:"
+
+# Parse the JSON template to list available servers
+if command -v jq >/dev/null 2>&1; then
+    # Use jq if available for proper JSON parsing
+    jq -r '.mcpServers | to_entries[] | "  - \(.key)"' ~/dotfiles/.mcp.json.template
+else
+    # Fallback to grep/sed for basic parsing - look for server names within mcpServers
+    # Look for lines with server names (indented exactly 4 spaces after mcpServers)
+    grep -E '^    "[^"]+": {$' ~/dotfiles/.mcp.json.template | sed 's/.*"\([^"]*\)".*/  - \1/'
+fi
+
+echo ""
+echo "Start Claude Code in this directory to use these MCP servers."

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Script to set up MCP servers in a Claude Code project
 
 # Check if we're in a git repository or project directory
@@ -13,25 +14,25 @@ fi
 
 # Check if .mcp.json already exists
 if [ -f ".mcp.json" ]; then
-    echo "Error: .mcp.json already exists in this directory."
-    echo "Remove it first if you want to set up MCP servers again."
+    echo "Error: .mcp.json already exists in this directory." >&2
+    echo "Remove it first if you want to set up MCP servers again." >&2
     exit 1
 fi
 
-# Copy the template
-cp ~/dotfiles/.mcp.json.template .mcp.json
+# Copy the template and replace __HOME__ with actual home directory
+sed "s|__HOME__|$HOME|g" ~/dotfiles/.mcp.json.template > .mcp.json
 
 echo "✅ MCP servers configured successfully!"
 echo "The following MCP servers are now available in this project:"
 
-# Parse the JSON template to list available servers
+# Parse the created .mcp.json file to list available servers
 if command -v jq >/dev/null 2>&1; then
     # Use jq if available for proper JSON parsing
-    jq -r '.mcpServers | to_entries[] | "  - \(.key)"' ~/dotfiles/.mcp.json.template
+    jq -r '.mcpServers | to_entries[] | "  - \(.key)"' .mcp.json
 else
     # Fallback to grep/sed for basic parsing - look for server names within mcpServers
     # Look for lines with server names (indented exactly 4 spaces after mcpServers)
-    grep -E '^    "[^"]+": {$' ~/dotfiles/.mcp.json.template | sed 's/.*"\([^"]*\)".*/  - \1/'
+    grep -E '^    "[^"]+": {$' .mcp.json | sed 's/.*"\([^"]*\)".*/  - \1/'
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- Added a template-based system for easily configuring MCP servers across Claude Code projects
- Fixed mcp-servers.nix to properly handle GitHub token loading for both Linux and macOS
- Created a setup script that dynamically lists available MCP servers

## Changes
1. **New `.mcp.json.template`**: Template file containing MCP server configurations that can be copied to any project
2. **New `scripts/setup-mcp.sh`**: Script that copies the template to create `.mcp.json` in any project directory
3. **Updated `home/mcp-servers.nix`**: 
   - Fixed systemd service to use wrapper script for proper GitHub token loading
   - Updated launchd configuration to use wrapper script for consistency
   - Added missing ReadWritePaths for npm cache directory

## Usage
To add MCP servers to any project:
```bash
cd /path/to/your/project
~/dotfiles/scripts/setup-mcp.sh
```

This will create a `.mcp.json` file in the project directory with all configured MCP servers.

🤖 Generated with [Claude Code](https://claude.ai/code)