### PR TITLE
fix: Resolve npm ENOTEMPTY errors during package updates

### DIFF
--- a/home/mcp-servers.nix
+++ b/home/mcp-servers.nix
@@ -96,9 +96,22 @@ in
       echo "✅ shadcn-ui-mcp-server installed successfully!"
     else
       echo "🔄 shadcn-ui-mcp-server already installed, checking for updates..."
-      npm update -g @jpisnice/shadcn-ui-mcp-server || {
-        echo "⚠️  Failed to update shadcn-ui-mcp-server, but continuing..."
-      }
+      # Check if update is available
+      CURRENT_VERSION=$(npm list -g @jpisnice/shadcn-ui-mcp-server --json 2>/dev/null | jq -r '.dependencies["@jpisnice/shadcn-ui-mcp-server"].version' 2>/dev/null || echo "0.0.0")
+      LATEST_VERSION=$(npm view @jpisnice/shadcn-ui-mcp-server version 2>/dev/null || echo "0.0.0")
+      
+      if [ "$CURRENT_VERSION" != "$LATEST_VERSION" ] && [ "$LATEST_VERSION" != "0.0.0" ]; then
+        echo "📦 Update available: $CURRENT_VERSION → $LATEST_VERSION"
+        # Clean up any leftover temp directories first
+        rm -rf $HOME/.npm-global/lib/node_modules/@jpisnice/.shadcn-ui-mcp-server-* 2>/dev/null || true
+        # Clean reinstall to avoid ENOTEMPTY errors
+        npm uninstall -g @jpisnice/shadcn-ui-mcp-server 2>/dev/null || true
+        npm install -g @jpisnice/shadcn-ui-mcp-server || {
+          echo "⚠️  Failed to update shadcn-ui-mcp-server, but continuing..."
+        }
+      else
+        echo "✅ shadcn-ui-mcp-server is up to date (version $CURRENT_VERSION)"
+      fi
     fi
   '';
 
@@ -129,9 +142,22 @@ in
       echo "✅ context7-mcp-server installed successfully!"
     else
       echo "🔄 context7-mcp-server already installed, checking for updates..."
-      npm update -g @upstash/context7-mcp || {
-        echo "⚠️  Failed to update context7-mcp-server, but continuing..."
-      }
+      # Check if update is available
+      CURRENT_VERSION=$(npm list -g @upstash/context7-mcp --json 2>/dev/null | jq -r '.dependencies["@upstash/context7-mcp"].version' 2>/dev/null || echo "0.0.0")
+      LATEST_VERSION=$(npm view @upstash/context7-mcp version 2>/dev/null || echo "0.0.0")
+      
+      if [ "$CURRENT_VERSION" != "$LATEST_VERSION" ] && [ "$LATEST_VERSION" != "0.0.0" ]; then
+        echo "📦 Update available: $CURRENT_VERSION → $LATEST_VERSION"
+        # Clean up any leftover temp directories first
+        rm -rf $HOME/.npm-global/lib/node_modules/@upstash/.context7-mcp-* 2>/dev/null || true
+        # Clean reinstall to avoid ENOTEMPTY errors
+        npm uninstall -g @upstash/context7-mcp 2>/dev/null || true
+        npm install -g @upstash/context7-mcp || {
+          echo "⚠️  Failed to update context7-mcp-server, but continuing..."
+        }
+      else
+        echo "✅ context7-mcp-server is up to date (version $CURRENT_VERSION)"
+      fi
     fi
   '';
 

--- a/home/npm-utils.nix
+++ b/home/npm-utils.nix
@@ -1,0 +1,59 @@
+# Shared utilities for npm package management
+{ pkgs }:
+
+{
+  # Reusable function to generate npm package installation/update script
+  mkNpmPackageActivation = { packageName, binaryName, displayName }: ''
+    set -e  # Exit on any error
+    
+    echo "🔧 Setting up ${displayName}..."
+    
+    # Create npm global directory in home
+    export NPM_CONFIG_PREFIX="$HOME/.npm-global"
+    mkdir -p "$HOME/.npm-global"
+    
+    # Add Node.js and npm to PATH for this activation script
+    export PATH="${pkgs.nodejs_22}/bin:${pkgs.nodePackages.npm}/bin:$PATH"
+    
+    echo "✅ node found: $(which node 2>/dev/null || echo 'node')"
+    echo "✅ npm found: $(which npm 2>/dev/null || echo 'npm')"
+    echo "📍 NPM prefix: $NPM_CONFIG_PREFIX"
+    
+    # Install or update the package
+    if [ ! -f "$HOME/.npm-global/bin/${binaryName}" ]; then
+      echo "📦 Installing ${displayName}..."
+      npm install -g ${packageName} || {
+        echo "❌ Failed to install ${displayName}"
+        exit 1
+      }
+      echo "✅ ${displayName} installed successfully!"
+    else
+      echo "🔄 ${displayName} already installed, checking for updates..."
+      # Check if update is available
+      CURRENT_VERSION=$(npm list -g ${packageName} --json 2>/dev/null | ${pkgs.jq}/bin/jq -r '.dependencies["${packageName}"].version' 2>/dev/null || echo "0.0.0")
+      LATEST_VERSION=$(npm view ${packageName} version 2>/dev/null || echo "0.0.0")
+      
+      if [ "$CURRENT_VERSION" != "$LATEST_VERSION" ] && [ "$LATEST_VERSION" != "0.0.0" ]; then
+        echo "📦 Update available: $CURRENT_VERSION → $LATEST_VERSION"
+        
+        # Extract org and package name for temp directory cleanup
+        ORG_NAME=$(echo "${packageName}" | cut -d'/' -f1)
+        PKG_NAME=$(echo "${packageName}" | cut -d'/' -f2)
+        
+        # Clean up any leftover temp directories first
+        rm -rf "$HOME/.npm-global/lib/node_modules/$ORG_NAME/.$PKG_NAME-"* 2>/dev/null || true
+        
+        # Clean reinstall to avoid ENOTEMPTY errors
+        npm uninstall -g ${packageName} 2>/dev/null || true
+        npm install -g ${packageName} || {
+          echo "⚠️  Failed to update ${displayName}, but continuing..."
+        }
+      else
+        echo "✅ ${displayName} is up to date (version $CURRENT_VERSION)"
+      fi
+    fi
+    
+    echo "📋 Contents of ~/.npm-global/bin/:"
+    ls -la "$HOME/.npm-global/bin/" || echo "Directory doesn't exist yet"
+  '';
+}

--- a/home/platforms.nix
+++ b/home/platforms.nix
@@ -39,6 +39,7 @@ in
       curl
       fish
       htop
+      jq
       nodejs_22
       nodePackages.npm
       ollama
@@ -59,6 +60,8 @@ in
     ++ lib.optionals isNixOS [
       # Add NixOS-specific packages here
       # e.g., packages that work better on NixOS
+      patchelf
+      gcc
     ]
     # Traditional Linux packages (Ubuntu, Fedora, etc. + Nix)
     ++ lib.optionals (isLinux && !isNixOS) [

--- a/home/programs.nix
+++ b/home/programs.nix
@@ -178,9 +178,22 @@ in
       echo "✅ Claude Code installed successfully!"
     else
       echo "🔄 Claude Code already installed, checking for updates..."
-      npm update -g @anthropic-ai/claude-code || {
-        echo "⚠️  Failed to update Claude Code, but continuing..."
-      }
+      # Check if update is available
+      CURRENT_VERSION=$(npm list -g @anthropic-ai/claude-code --json 2>/dev/null | jq -r '.dependencies["@anthropic-ai/claude-code"].version' 2>/dev/null || echo "0.0.0")
+      LATEST_VERSION=$(npm view @anthropic-ai/claude-code version 2>/dev/null || echo "0.0.0")
+      
+      if [ "$CURRENT_VERSION" != "$LATEST_VERSION" ] && [ "$LATEST_VERSION" != "0.0.0" ]; then
+        echo "📦 Update available: $CURRENT_VERSION → $LATEST_VERSION"
+        # Clean up any leftover temp directories first
+        rm -rf $HOME/.npm-global/lib/node_modules/@anthropic-ai/.claude-code-* 2>/dev/null || true
+        # Clean reinstall to avoid ENOTEMPTY errors
+        npm uninstall -g @anthropic-ai/claude-code 2>/dev/null || true
+        npm install -g @anthropic-ai/claude-code || {
+          echo "⚠️  Failed to update Claude Code, but continuing..."
+        }
+      else
+        echo "✅ Claude Code is up to date (version $CURRENT_VERSION)"
+      fi
     fi
     
     echo "📋 Contents of ~/.npm-global/bin/:"
@@ -214,9 +227,22 @@ in
       echo "✅ Google Gemini CLI installed successfully!"
     else
       echo "🔄 Google Gemini CLI already installed, checking for updates..."
-      npm update -g @google/gemini-cli || {
-        echo "⚠️  Failed to update Google Gemini CLI, but continuing..."
-      }
+      # Check if update is available
+      CURRENT_VERSION=$(npm list -g @google/gemini-cli --json 2>/dev/null | jq -r '.dependencies["@google/gemini-cli"].version' 2>/dev/null || echo "0.0.0")
+      LATEST_VERSION=$(npm view @google/gemini-cli version 2>/dev/null || echo "0.0.0")
+      
+      if [ "$CURRENT_VERSION" != "$LATEST_VERSION" ] && [ "$LATEST_VERSION" != "0.0.0" ]; then
+        echo "📦 Update available: $CURRENT_VERSION → $LATEST_VERSION"
+        # Clean up any leftover temp directories first
+        rm -rf $HOME/.npm-global/lib/node_modules/@google/.gemini-cli-* 2>/dev/null || true
+        # Clean reinstall to avoid ENOTEMPTY errors
+        npm uninstall -g @google/gemini-cli 2>/dev/null || true
+        npm install -g @google/gemini-cli || {
+          echo "⚠️  Failed to update Google Gemini CLI, but continuing..."
+        }
+      else
+        echo "✅ Google Gemini CLI is up to date (version $CURRENT_VERSION)"
+      fi
     fi
     
     echo "📋 Contents of ~/.npm-global/bin/:"


### PR DESCRIPTION
- Replace npm update with version-checked clean reinstalls
- Add automatic cleanup of leftover npm temp directories
- Add jq dependency for JSON parsing in version checks
- Only reinstall packages when newer versions are available

This fixes the ENOTEMPTY directory rename errors that were occurring during home-manager activation when updating npm global packages.i

Also added patchelf & gcc to the NixOS packages stanza as these packages are required for the changes in commit 229072e to ensure that the vscode script is able to automatically adjust for updates.

🤖 Generated with [Claude Code](https://claude.ai/code)