### PR TITLE
feat: Add automated flake updates and portable Nix version management

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -77,6 +77,8 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          # Note: PRs created with GITHUB_TOKEN won't trigger other workflows.
+          # Use a PAT or GitHub App token if CI checks are needed on these PRs.
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update flake inputs"
           title: "chore: update flake inputs"

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -1,0 +1,86 @@
+name: Update Flake Inputs
+
+on:
+  schedule:
+    # Runs every Monday at 9:00 AM UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Update flake inputs
+        run: nix flake update
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet flake.lock; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup CI user config
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          # Create a working user-config.nix for CI builds
+          cat > user-config.nix << 'EOF'
+          {
+            username = "runner";
+            homeDirectory = "/home/runner";
+            git = {
+              name = "CI Runner";
+              email = "ci@example.com";
+            };
+            windowsUsername = "runner";
+            stateVersion = "24.11";
+          }
+          EOF
+
+      - name: Build home-manager config (x86_64-linux)
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          nix build '.#homeConfigurations."runner@x86_64-linux".activationPackage' --no-link
+
+      - name: Generate update summary
+        if: steps.changes.outputs.changed == 'true'
+        id: summary
+        run: |
+          {
+            echo 'body<<EOF'
+            echo 'Automated flake input updates.'
+            echo ''
+            echo '## Updated inputs'
+            echo '```'
+            nix flake metadata --json | jq -r '.locks.nodes | to_entries[] | select(.value.locked.rev) | "\(.key): \(.value.locked.rev[0:7])"'
+            echo '```'
+            echo ''
+            echo '## Checklist'
+            echo '- [ ] Review the changes in `flake.lock`'
+            echo '- [ ] Test locally with `nix run .#home-manager -- switch --flake .`'
+            echo '- [ ] Verify on other platforms if needed (macOS, WSL)'
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update flake inputs"
+          title: "chore: update flake inputs"
+          body: ${{ steps.summary.outputs.body }}
+          branch: automated/flake-update
+          delete-branch: true
+          labels: dependencies

--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -10,6 +10,7 @@ in
   networking.computerName = "CxGawd";
 
   # Nix configuration
+  nix.package = pkgs.nixVersions.latest;
   nix.settings = {
     experimental-features = [ "nix-command" "flakes" ];
     # Use binary caches to avoid building from source
@@ -49,8 +50,8 @@ in
   # Home Manager integration
   # This is configured in the flake.nix
 
-  # Auto upgrade nix package and the daemon service.
-  # services.nix-daemon.enable = true;
+  # Manage the Nix daemon (required for nix.package to take effect)
+  services.nix-daemon.enable = true;
 
   # Used for backwards compatibility, please read the changelog before changing.
   # $ darwin-rebuild changelog

--- a/home/platforms.nix
+++ b/home/platforms.nix
@@ -34,12 +34,12 @@ in
 {
   # Nix version check for standalone Linux (where Nix isn't managed declaratively)
   home.activation.nixVersionCheck = lib.mkIf (isLinux && !isNixOS) (config.lib.dag.entryAfter ["writeBoundary"] ''
-    # Get current Nix version
-    CURRENT_NIX=$(nix --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -1)
+    # Get current Nix version (full semver including patch)
+    CURRENT_NIX=$(nix --version 2>/dev/null | grep -oE '[0-9]+(\.[0-9]+)+' | head -1)
     # Get latest Nix version available in nixpkgs
-    LATEST_NIX=$(nix eval --raw nixpkgs#nixVersions.latest.version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' || echo "unknown")
+    LATEST_NIX=$(nix eval --raw nixpkgs#nixVersions.latest.version 2>/dev/null || echo "unknown")
 
-    if [ "$LATEST_NIX" != "unknown" ] && [ "$CURRENT_NIX" != "$LATEST_NIX" ]; then
+    if [ -n "$CURRENT_NIX" ] && [ "$LATEST_NIX" != "unknown" ] && [ "$CURRENT_NIX" != "$LATEST_NIX" ]; then
       echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
       echo "ℹ️  Nix upgrade available: $CURRENT_NIX → $LATEST_NIX"
       echo ""

--- a/home/platforms.nix
+++ b/home/platforms.nix
@@ -32,6 +32,22 @@ let
 in
 
 {
+  # Nix version check for standalone Linux (where Nix isn't managed declaratively)
+  home.activation.nixVersionCheck = lib.mkIf (isLinux && !isNixOS) (config.lib.dag.entryAfter ["writeBoundary"] ''
+    # Get current Nix version
+    CURRENT_NIX=$(nix --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -1)
+    # Get latest Nix version available in nixpkgs
+    LATEST_NIX=$(nix eval --raw nixpkgs#nixVersions.latest.version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' || echo "unknown")
+
+    if [ "$LATEST_NIX" != "unknown" ] && [ "$CURRENT_NIX" != "$LATEST_NIX" ]; then
+      echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+      echo "ℹ️  Nix upgrade available: $CURRENT_NIX → $LATEST_NIX"
+      echo ""
+      echo "Run 'nix-upgrade' to update Nix on this system."
+      echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    fi
+  '');
+
   # Font installation note for macOS
   home.activation.fontNote = lib.mkIf isDarwin (config.lib.dag.entryAfter ["writeBoundary"] ''
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -26,7 +26,8 @@ in
     options = [ "nofail" ];
   };
 
-  # Enable flakes
+  # Nix configuration
+  nix.package = pkgs.nixVersions.latest;
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
   
   networking.hostName = "wsl"; # <- must match the flake output key

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -54,6 +54,7 @@ in
   ];
 
   programs.fish.enable = true;
+  programs.command-not-found.enable = true;
 
   # Enable nix-ld to run unpatched dynamic binaries on NixOS
   programs.nix-ld.enable = true;

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -27,7 +27,6 @@ in
   };
 
   # Nix configuration
-  nix.package = pkgs.nixVersions.latest;
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
   
   networking.hostName = "wsl"; # <- must match the flake output key
@@ -54,6 +53,8 @@ in
   ];
 
   programs.fish.enable = true;
+
+  # command-not-found works with flakes via the programs-sqlite database
   programs.command-not-found.enable = true;
 
   # Enable nix-ld to run unpatched dynamic binaries on NixOS


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow for weekly automated flake input updates with PR creation
- Add portable Nix version management across platforms (macOS, NixOS, standalone Linux)
- Add `nix-upgrade` fish function that provides platform-appropriate upgrade guidance
- Enable command-not-found on NixOS using the flake-compatible programs-sqlite database

## Platform-specific Nix management

| Platform | Approach |
|----------|----------|
| **macOS (nix-darwin)** | `nix.package = pkgs.nixVersions.latest` with daemon service |
| **NixOS** | Let NixOS manage Nix automatically (explicit `nix.package` caused rebuild crashes) |
| **Standalone Linux** | Activation script notifies about available upgrades; `nix-upgrade` runs `nix upgrade-nix` |

## Test plan

- [x] Test `nixos-rebuild switch` on NixOS-WSL
- [ ] Test `darwin-rebuild switch` on macOS
- [ ] Test `home-manager switch` on standalone Linux
- [ ] Verify GitHub Actions workflow runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)