### PR TITLE
chore(ci): automate dependency + tool-deprecation freshness

### DIFF
--- a/.github/workflows/audit-tools.yml
+++ b/.github/workflows/audit-tools.yml
@@ -82,6 +82,10 @@ jobs:
             if [ "$archived" = "true" ]; then
               hard=1
               echo "- **$repo** — ⚠️ REPOSITORY ARCHIVED (last push $pushed)" >> prompt.md
+            elif [ "$archived" = "unknown" ]; then
+              # Don't let a failed/rate-limited API call masquerade as "active".
+              hard=1
+              echo "- **$repo** — ⚠️ COULD NOT VERIFY (GitHub API error or rate limit)" >> prompt.md
             else
               echo "- $repo — active (last push $pushed)" >> prompt.md
             fi
@@ -89,8 +93,8 @@ jobs:
 
           echo "" >> prompt.md
           echo "## Pinned release binaries (fetchurl)" >> prompt.md
-          # Match .../<owner>/<repo>/releases/download/<tag>/...
-          grep -rhoE 'github\.com/[^/]+/[^/]+/releases/download/[^/]+' . 2>/dev/null \
+          # Match .../<owner>/<repo>/releases/download/<tag>/... in Nix sources only
+          grep -rhoE --include='*.nix' --exclude-dir='.git' 'github\.com/[^/]+/[^/]+/releases/download/[^/]+' . 2>/dev/null \
             | sed -E 's#.*github\.com/([^/]+)/([^/]+)/releases/download/([^/]+).*#\1/\2 \3#' \
             | sort -u | while read -r repo pinned; do
               latest_tag=$(gh api "repos/$repo/releases/latest" --jq '.tag_name' 2>/dev/null || echo "unknown")

--- a/.github/workflows/audit-tools.yml
+++ b/.github/workflows/audit-tools.yml
@@ -1,0 +1,154 @@
+name: Audit Tools for Deprecation
+
+# Catches the class of staleness that `nix flake update` CANNOT: a tool being
+# deprecated, unmaintained, or superseded by a DIFFERENT tool (e.g. Gemini CLI
+# -> Antigravity CLI). Version bumps are handled by update-flake.yml.
+#
+# Uses ONLY the built-in GITHUB_TOKEN — no external API key required:
+#   * authoritative signals are gathered deterministically (npm deprecation,
+#     GitHub repo archival, release-tag drift);
+#   * GitHub Models (included with Copilot) writes the summary and judges
+#     supersession, via actions/ai-inference and `models: read`.
+# Opens/updates a single issue labeled `tool-audit` when action is needed.
+
+on:
+  schedule:
+    # 10:00 UTC on the 1st of every month
+    - cron: "0 10 1 * *"
+  workflow_dispatch: # Allow manual triggering
+
+concurrency:
+  group: audit-tools
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      models: read # GitHub Models inference via GITHUB_TOKEN
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Gather deterministic signals
+        id: gather
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          hard=0
+          {
+            echo "# Tool audit input"
+            echo
+            echo "Assess the tools below for DEPRECATION and SUPERSESSION only."
+            echo "Hard signals (deprecation, repo archived, release-tag drift) are"
+            echo "pre-computed and authoritative. Your job: (1) confirm/explain each"
+            echo "hard signal briefly, and (2) using your own knowledge, flag any tool"
+            echo "that has been SUPERSEDED by a different recommended tool. Be"
+            echo "conservative — do not invent deprecations."
+            echo
+            echo "Reply in GitHub-flavored markdown. The VERY FIRST line must be"
+            echo "exactly 'STATUS: ACTION_NEEDED' or 'STATUS: OK'. Then a short table"
+            echo "(Tool | Source | Finding | Recommendation) followed by any details."
+            echo
+            echo "## npm packages (installed at Home Manager activation)"
+          } > prompt.md
+
+          # npm packages referenced by mkNpmPackageActivation
+          for pkg in $(grep -rhoE 'packageName = "[^"]+"' home | sed -E 's/.*"([^"]+)".*/\1/' | sort -u); do
+            latest=$(npm view "$pkg" version 2>/dev/null || echo "unknown")
+            dep=$(npm view "$pkg" deprecated 2>/dev/null || echo "")
+            modified=$(npm view "$pkg" time.modified 2>/dev/null || echo "unknown")
+            if [ -n "$dep" ]; then
+              hard=1
+              echo "- **$pkg** — latest \`$latest\`, last publish $modified — ⚠️ DEPRECATED: $dep" >> prompt.md
+            else
+              echo "- $pkg — latest \`$latest\`, last publish $modified — no npm deprecation flag" >> prompt.md
+            fi
+          done
+
+          echo "" >> prompt.md
+          echo "## Flake inputs (github repos)" >> prompt.md
+          for repo in $(grep -oE 'github:[^/"]+/[^/"]+' flake.nix | sed 's#github:##' | sort -u); do
+            info=$(gh api "repos/$repo" --jq '"\(.archived)|\(.pushed_at)"' 2>/dev/null || echo "unknown|unknown")
+            archived=${info%%|*}; pushed=${info##*|}
+            if [ "$archived" = "true" ]; then
+              hard=1
+              echo "- **$repo** — ⚠️ REPOSITORY ARCHIVED (last push $pushed)" >> prompt.md
+            else
+              echo "- $repo — active (last push $pushed)" >> prompt.md
+            fi
+          done
+
+          echo "" >> prompt.md
+          echo "## Pinned release binaries (fetchurl)" >> prompt.md
+          # Match .../<owner>/<repo>/releases/download/<tag>/...
+          grep -rhoE 'github\.com/[^/]+/[^/]+/releases/download/[^/]+' . 2>/dev/null \
+            | sed -E 's#.*github\.com/([^/]+)/([^/]+)/releases/download/([^/]+).*#\1/\2 \3#' \
+            | sort -u | while read -r repo pinned; do
+              latest_tag=$(gh api "repos/$repo/releases/latest" --jq '.tag_name' 2>/dev/null || echo "unknown")
+              if [ "$latest_tag" != "unknown" ] && [ "$latest_tag" != "$pinned" ]; then
+                echo "- **$repo** — pinned \`$pinned\`, latest release \`$latest_tag\` — ⚠️ BEHIND" >> prompt.md
+              else
+                echo "- $repo — pinned \`$pinned\` (latest \`$latest_tag\`)" >> prompt.md
+              fi
+          done
+          # Release-tag drift is detected in the subshell above; surface it too.
+          if grep -q '⚠️ BEHIND' prompt.md; then hard=1; fi
+
+          echo "" >> prompt.md
+          echo "## Other pinned tools (judge by knowledge)" >> prompt.md
+          grep -qE 'nodejs_[0-9]+' home/*.nix && \
+            echo "- $(grep -rhoE 'nodejs_[0-9]+' home | sort -u | tr '\n' ' ') — pinned Node.js major(s)" >> prompt.md || true
+
+          echo "hard_signal=$hard" >> "$GITHUB_OUTPUT"
+          echo "----- prompt.md -----"; cat prompt.md
+
+      - name: Assess with GitHub Models
+        id: ai
+        uses: actions/ai-inference@v1
+        with:
+          model: openai/gpt-4o
+          prompt-file: prompt.md
+          max-tokens: 1500
+
+      - name: Open or update audit issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HARD_SIGNAL: ${{ steps.gather.outputs.hard_signal }}
+          AI_RESPONSE: ${{ steps.ai.outputs.response }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -uo pipefail
+          printf '%s\n' "$AI_RESPONSE" > report.md
+          printf '\n\n---\n_Automated tool audit — [run log](%s)_\n' "$RUN_URL" >> report.md
+
+          action_needed=0
+          if [ "$HARD_SIGNAL" = "1" ]; then action_needed=1; fi
+          if head -n1 report.md | grep -q 'ACTION_NEEDED'; then action_needed=1; fi
+
+          existing=$(gh issue list --label tool-audit --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ "$action_needed" = "1" ]; then
+            gh label create tool-audit --color BFDADC --description "Automated tool deprecation audit" --force || true
+            if [ -n "$existing" ]; then
+              gh issue edit "$existing" --body-file report.md
+              gh issue comment "$existing" --body "Re-audited: still needs attention (see updated body). Run: $RUN_URL"
+              echo "Updated issue #$existing"
+            else
+              gh issue create --title "Tool audit: action needed" --label tool-audit --body-file report.md
+              echo "Opened new audit issue"
+            fi
+          else
+            echo "No action needed."
+            if [ -n "$existing" ]; then
+              gh issue comment "$existing" --body "Latest audit is clean. Run: $RUN_URL"
+            fi
+          fi

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -6,6 +6,11 @@ on:
     - cron: "0 9 * * 1"
   workflow_dispatch: # Allow manual triggering
 
+# Avoid overlapping runs racing on the same branch
+concurrency:
+  group: flake-update
+  cancel-in-progress: true
+
 jobs:
   update:
     runs-on: ubuntu-latest
@@ -37,7 +42,9 @@ jobs:
       - name: Setup CI user config
         if: steps.changes.outputs.changed == 'true'
         run: |
-          # Create a working user-config.nix for CI builds
+          # Create a working user-config.nix for CI builds.
+          # `system` is set so the flake evaluates fully; it's only actually
+          # consumed by the nixos/darwin system configs (not built here).
           cat > user-config.nix << 'EOF'
           {
             username = "runner";
@@ -47,14 +54,28 @@ jobs:
               email = "ci@example.com";
             };
             windowsUsername = "runner";
+            system = "x86_64-linux";
             stateVersion = "24.11";
           }
           EOF
 
-      - name: Build home-manager config (x86_64-linux)
+      # --- Validation -------------------------------------------------------
+      # We build the x86_64-linux home config natively. We deliberately do NOT
+      # build the other configs here, because a plain Linux runner cannot:
+      #   * darwin / aarch64: evaluating them forces an import-from-derivation
+      #     that must BUILD a foreign-system derivation — impossible without a
+      #     matching runner (macOS) or emulation.
+      #   * nixosConfigurations.wsl: imports /etc/nixos/hardware-configuration.nix
+      #     by absolute path (machine-specific, gitignored), which is forbidden
+      #     in pure flake eval and absent in CI.
+      # See the repo docs for opt-in ways to validate those (macOS matrix job;
+      # impure WSL build with a stub hardware-configuration.nix).
+
+      - name: Build home config (x86_64-linux)
         if: steps.changes.outputs.changed == 'true'
         run: |
-          nix build '.#homeConfigurations."runner@x86_64-linux".activationPackage' --no-link
+          nix build '.#homeConfigurations."runner@x86_64-linux".activationPackage' --no-link --print-build-logs
+      # ----------------------------------------------------------------------
 
       - name: Generate update summary
         if: steps.changes.outputs.changed == 'true'
@@ -69,10 +90,16 @@ jobs:
             nix flake metadata --json | jq -r '.locks.nodes | to_entries[] | select(.value.locked.rev) | "\(.key): \(.value.locked.rev[0:7])"'
             echo '```'
             echo ''
+            echo '## Validated in CI (x86_64-linux runner)'
+            echo '- [x] Built `homeConfigurations."*@x86_64-linux"` (native build)'
+            echo '- [ ] darwin / aarch64 NOT validated here (needs a macOS runner)'
+            echo '- [ ] `nixosConfigurations.wsl` NOT validated here (absolute hardware-configuration.nix import)'
+            echo ''
             echo '## Checklist'
             echo '- [ ] Review the changes in `flake.lock`'
-            echo '- [ ] Test locally with `nix run .#home-manager -- switch --flake .`'
-            echo '- [ ] Verify on other platforms if needed (macOS, WSL)'
+            echo '- [ ] Test on WSL: `sudo nixos-rebuild switch --flake .#wsl`'
+            echo '- [ ] Test home config: `nix run .#home-manager -- switch --flake .`'
+            echo '- [ ] On a Mac: `darwin-rebuild build --flake .` if a darwin-specific change is suspected'
             echo 'EOF'
           } >> $GITHUB_OUTPUT
 

--- a/README.md
+++ b/README.md
@@ -414,6 +414,40 @@ home-manager switch --flake .#$(whoami)@aarch64-darwin
 home-manager switch --flake .#$(whoami)@x86_64-linux
 ```
 
+### Automated maintenance (GitHub Actions)
+
+Two scheduled workflows keep the repo from going stale:
+
+- **`.github/workflows/update-flake.yml`** — weekly (Mondays 09:00 UTC). Runs
+  `nix flake update`, builds the `x86_64-linux` home config to catch breakage,
+  and opens a PR labeled `dependencies`. This keeps *versions* current
+  (including Nix itself, which ships via `nixpkgs`).
+- **`.github/workflows/audit-tools.yml`** — monthly (1st, 10:00 UTC). Checks
+  each externally-sourced tool (flake inputs, npm packages, pinned `fetchurl`
+  binaries) for **deprecation or supersession** — the kind of staleness
+  `nix flake update` can't detect (e.g. a tool being replaced by a different
+  one, as Gemini CLI was by Antigravity CLI). Authoritative signals (npm
+  deprecation, GitHub repo archival, release-tag drift) are gathered
+  deterministically; **GitHub Models** (included with Copilot, via
+  `actions/ai-inference` + the built-in `GITHUB_TOKEN` — **no external API key
+  required**) writes the summary and judges supersession. Opens/updates a single
+  issue labeled `tool-audit` when action is needed.
+
+#### TODO: broaden update-flake.yml CI validation
+
+The flake-update workflow currently only builds the `x86_64-linux` home config,
+because a plain Linux runner cannot validate the other targets:
+
+- [ ] **macOS / darwin** — evaluating a darwin config forces an
+  import-from-derivation that must *build* an `aarch64-darwin` derivation, which
+  a Linux runner can't do. Add a `macos-latest` matrix job that really builds it
+  (e.g. `homeConfigurations."runner@aarch64-darwin".activationPackage`, or
+  `darwin-rebuild build --flake .`).
+- [ ] **NixOS-WSL** — `nixosConfigurations.wsl` imports
+  `/etc/nixos/hardware-configuration.nix` by absolute path, which is
+  machine-specific, gitignored, and forbidden in pure flake eval. To validate in
+  CI, generate a stub `hardware-configuration.nix` and build with `--impure`.
+
 ## 🛠️ Customization
 
 ### Adding Packages

--- a/user-config.nix
+++ b/user-config.nix
@@ -16,5 +16,6 @@
   windowsUsername = "your-windows-username"; # Your Windows username for WSL VS Code integration
   
   # System settings
+  system = "x86_64-linux"; # Your system architecture (e.g., "x86_64-linux", "aarch64-linux", "aarch64-darwin")
   stateVersion = "24.11"; # Home Manager state version - see https://nix-community.github.io/home-manager/release-notes.html
 }


### PR DESCRIPTION
## Summary

Keeps the repo from going stale across the **three distinct axes** of "out of date," only one of which was previously automated:

1. **Versions of pinned inputs** — already handled by `update-flake.yml` (weekly `nix flake update` → PR).
2. **Auto-latest npm tools** — self-update at activation (unchanged here).
3. **Tool relevance / deprecation** — *previously unhandled.* `nix flake update` can never tell you a tool was deprecated or replaced by a different one (the Gemini CLI → Antigravity CLI case). This PR adds that.

## Changes

- **`audit-tools.yml` (new)** — monthly (+ manual) audit for **deprecation / supersession**. Gathers authoritative signals deterministically (`npm view … deprecated`, GitHub repo `archived`, release-tag drift on pinned `fetchurl` binaries) and uses **GitHub Models** (included with Copilot, via `actions/ai-inference` + the built-in `GITHUB_TOKEN`) to summarize and judge supersession. Opens/updates a single issue labeled `tool-audit`. **No external API key required.**
- **`update-flake.yml`** — added a `concurrency` guard and an accurate CI summary; documents why darwin and NixOS-WSL configs can't be built on a plain Linux runner.
- **`user-config.nix`** — added the missing `system` field to the committed template so fresh clones can build `nixosConfigurations.wsl`.
- **`README.md`** — new "Automated maintenance" section + a TODO checklist for broadening CI to macOS/WSL.

## CI coverage limits (documented, deferred as TODO)

A plain Linux runner **cannot** validate:
- **darwin** — evaluating the config forces an import-from-derivation that must *build* an `aarch64-darwin` derivation.
- **NixOS-WSL** — imports `/etc/nixos/hardware-configuration.nix` by absolute path (machine-specific, gitignored, forbidden in pure eval).

So `update-flake.yml` builds only the `x86_64-linux` home config (verified working). The macOS-matrix and impure-WSL approaches are captured as a TODO checklist in the README.

## Testing notes

- ✅ `homeConfigurations."*@x86_64-linux"` builds (verified locally via `getFlake`).
- ✅ Corrected `user-config.nix` template staged without touching the skip-worktree working copy; no personal values committed.
- ⚠️ **`audit-tools.yml` is unproven end-to-end** — GitHub Actions couldn't run locally. Please do a first `workflow_dispatch` run to confirm GitHub Models is enabled and `actions/ai-inference@v1` behaves as expected. The deterministic signal-gathering steps are standard `gh`/shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)