### PR TITLE
fix(ci): run tool audit via GitHub Copilot CLI (GitHub Models retired)

### DIFF
--- a/.github/workflows/audit-tools.yml
+++ b/.github/workflows/audit-tools.yml
@@ -2,14 +2,20 @@ name: Audit Tools for Deprecation
 
 # Catches the class of staleness that `nix flake update` CANNOT: a tool being
 # deprecated, unmaintained, or superseded by a DIFFERENT tool (e.g. Gemini CLI
-# -> Antigravity CLI). Version bumps are handled by update-flake.yml.
+# -> Antigravity CLI). Version bumps of flake inputs are handled by
+# update-flake.yml.
 #
-# Uses ONLY the built-in GITHUB_TOKEN — no external API key required:
-#   * authoritative signals are gathered deterministically (npm deprecation,
-#     GitHub repo archival, release-tag drift);
-#   * GitHub Models (included with Copilot) writes the summary and judges
-#     supersession, via actions/ai-inference and `models: read`.
-# Opens/updates a single issue labeled `tool-audit` when action is needed.
+# Two layers:
+#   1. Deterministic, authoritative signals (need no model): npm deprecation
+#      flags, GitHub repo archival, release-tag drift for pinned fetchurl bins.
+#   2. GitHub Copilot judges SUPERSESSION and writes the summary, via the
+#      Copilot CLI + actions/ai-inference.
+#
+# NOTE: the free GitHub Models endpoint was retired 2026-07-30. actions/ai-inference
+# now runs on the GitHub Copilot CLI, which authenticates with a Copilot-enabled
+# token — NOT the built-in GITHUB_TOKEN. Add a repo secret `COPILOT_PAT`:
+# a (fine-grained) Personal Access Token from an account with an active Copilot
+# subscription. Opens/updates a single issue labeled `tool-audit` when needed.
 
 on:
   schedule:
@@ -27,7 +33,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-      models: read # GitHub Models inference via GITHUB_TOKEN
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -35,7 +40,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Gather deterministic signals
         id: gather
@@ -43,7 +48,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
-          hard=0
           {
             echo "# Tool audit input"
             echo
@@ -67,7 +71,6 @@ jobs:
             dep=$(npm view "$pkg" deprecated 2>/dev/null || echo "")
             modified=$(npm view "$pkg" time.modified 2>/dev/null || echo "unknown")
             if [ -n "$dep" ]; then
-              hard=1
               echo "- **$pkg** — latest \`$latest\`, last publish $modified — ⚠️ DEPRECATED: $dep" >> prompt.md
             else
               echo "- $pkg — latest \`$latest\`, last publish $modified — no npm deprecation flag" >> prompt.md
@@ -80,11 +83,9 @@ jobs:
             info=$(gh api "repos/$repo" --jq '"\(.archived)|\(.pushed_at)"' 2>/dev/null || echo "unknown|unknown")
             archived=${info%%|*}; pushed=${info##*|}
             if [ "$archived" = "true" ]; then
-              hard=1
               echo "- **$repo** — ⚠️ REPOSITORY ARCHIVED (last push $pushed)" >> prompt.md
             elif [ "$archived" = "unknown" ]; then
               # Don't let a failed/rate-limited API call masquerade as "active".
-              hard=1
               echo "- **$repo** — ⚠️ COULD NOT VERIFY (GitHub API error or rate limit)" >> prompt.md
             else
               echo "- $repo — active (last push $pushed)" >> prompt.md
@@ -104,22 +105,32 @@ jobs:
                 echo "- $repo — pinned \`$pinned\` (latest \`$latest_tag\`)" >> prompt.md
               fi
           done
-          # Release-tag drift is detected in the subshell above; surface it too.
-          if grep -q '⚠️ BEHIND' prompt.md; then hard=1; fi
 
           echo "" >> prompt.md
           echo "## Other pinned tools (judge by knowledge)" >> prompt.md
-          grep -qE 'nodejs_[0-9]+' home/*.nix && \
-            echo "- $(grep -rhoE 'nodejs_[0-9]+' home | sort -u | tr '\n' ' ') — pinned Node.js major(s)" >> prompt.md || true
+          nodejs_pins=$(grep -rhoE 'nodejs_[0-9]+' home 2>/dev/null | sort -u | tr '\n' ' ')
+          [ -n "$nodejs_pins" ] && echo "- Pinned Node.js major(s): \`$nodejs_pins\`" >> prompt.md
 
+          # A warning marker (⚠️) anywhere means human attention is needed,
+          # independent of what the model concludes.
+          if grep -q '⚠️' prompt.md; then hard=1; else hard=0; fi
           echo "hard_signal=$hard" >> "$GITHUB_OUTPUT"
           echo "----- prompt.md -----"; cat prompt.md
 
-      - name: Assess with GitHub Models
+      - name: Install GitHub Copilot CLI
+        run: npm install -g @github/copilot
+
+      - name: Assess with GitHub Copilot
         id: ai
         uses: actions/ai-inference@v1
+        env:
+          # A Copilot-enabled token is required — the built-in GITHUB_TOKEN
+          # does NOT work. Create secret COPILOT_PAT (see header comment).
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT }}
         with:
-          model: openai/gpt-4o
+          # gpt-4.1 is the documented default and widely available; swap to
+          # claude-sonnet-4.5 if your Copilot plan includes it.
+          model: gpt-4.1
           prompt-file: prompt.md
           max-tokens: 1500
 
@@ -153,6 +164,7 @@ jobs:
           else
             echo "No action needed."
             if [ -n "$existing" ]; then
-              gh issue comment "$existing" --body "Latest audit is clean. Run: $RUN_URL"
+              gh issue comment "$existing" --body "Latest audit is clean — closing. Run: $RUN_URL"
+              gh issue close "$existing"
             fi
           fi

--- a/.github/workflows/audit-tools.yml
+++ b/.github/workflows/audit-tools.yml
@@ -8,14 +8,17 @@ name: Audit Tools for Deprecation
 # Two layers:
 #   1. Deterministic, authoritative signals (need no model): npm deprecation
 #      flags, GitHub repo archival, release-tag drift for pinned fetchurl bins.
-#   2. GitHub Copilot judges SUPERSESSION and writes the summary, via the
-#      Copilot CLI + actions/ai-inference.
+#      These ALWAYS run and, on their own, drive issue creation.
+#   2. GitHub Copilot judges SUPERSESSION and writes a nicer summary, via the
+#      Copilot CLI + actions/ai-inference. This layer is OPTIONAL: it is skipped
+#      when COPILOT_PAT is absent and is allowed to fail without failing the job,
+#      in which case the issue falls back to the deterministic findings.
 #
 # NOTE: the free GitHub Models endpoint was retired 2026-07-30. actions/ai-inference
 # now runs on the GitHub Copilot CLI, which authenticates with a Copilot-enabled
-# token — NOT the built-in GITHUB_TOKEN. Add a repo secret `COPILOT_PAT`:
-# a (fine-grained) Personal Access Token from an account with an active Copilot
-# subscription. Opens/updates a single issue labeled `tool-audit` when needed.
+# token — NOT the built-in GITHUB_TOKEN. To enable layer 2, add a repo secret
+# `COPILOT_PAT`: a (fine-grained) Personal Access Token from an account with an
+# active Copilot subscription. Opens/updates a single issue labeled `tool-audit`.
 
 on:
   schedule:
@@ -33,6 +36,11 @@ jobs:
     permissions:
       contents: read
       issues: write
+    env:
+      # Whether the optional Copilot layer can run. Mapped to a boolean here so
+      # step-level `if:` can gate on it (the `secrets` context isn't available
+      # directly in step conditionals).
+      HAS_COPILOT_PAT: ${{ secrets.COPILOT_PAT != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -48,80 +56,89 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
-          {
-            echo "# Tool audit input"
-            echo
-            echo "Assess the tools below for DEPRECATION and SUPERSESSION only."
-            echo "Hard signals (deprecation, repo archived, release-tag drift) are"
-            echo "pre-computed and authoritative. Your job: (1) confirm/explain each"
-            echo "hard signal briefly, and (2) using your own knowledge, flag any tool"
-            echo "that has been SUPERSEDED by a different recommended tool. Be"
-            echo "conservative — do not invent deprecations."
-            echo
-            echo "Reply in GitHub-flavored markdown. The VERY FIRST line must be"
-            echo "exactly 'STATUS: ACTION_NEEDED' or 'STATUS: OK'. Then a short table"
-            echo "(Tool | Source | Finding | Recommendation) followed by any details."
-            echo
-            echo "## npm packages (installed at Home Manager activation)"
-          } > prompt.md
+          # findings.md = clean, human-readable deterministic report (also the
+          # fallback issue body). prompt.md = findings wrapped with instructions
+          # for the optional Copilot layer.
+          : > findings.md
 
-          # npm packages referenced by mkNpmPackageActivation
+          echo "### npm packages (installed at Home Manager activation)" >> findings.md
           for pkg in $(grep -rhoE 'packageName = "[^"]+"' home | sed -E 's/.*"([^"]+)".*/\1/' | sort -u); do
             latest=$(npm view "$pkg" version 2>/dev/null || echo "unknown")
             dep=$(npm view "$pkg" deprecated 2>/dev/null || echo "")
             modified=$(npm view "$pkg" time.modified 2>/dev/null || echo "unknown")
             if [ -n "$dep" ]; then
-              echo "- **$pkg** — latest \`$latest\`, last publish $modified — ⚠️ DEPRECATED: $dep" >> prompt.md
+              echo "- **$pkg** — latest \`$latest\`, last publish $modified — ⚠️ DEPRECATED: $dep" >> findings.md
             else
-              echo "- $pkg — latest \`$latest\`, last publish $modified — no npm deprecation flag" >> prompt.md
+              echo "- $pkg — latest \`$latest\`, last publish $modified — ✅ no deprecation flag" >> findings.md
             fi
           done
 
-          echo "" >> prompt.md
-          echo "## Flake inputs (github repos)" >> prompt.md
+          echo "" >> findings.md
+          echo "### Flake inputs (GitHub repos)" >> findings.md
           for repo in $(grep -oE 'github:[^/"]+/[^/"]+' flake.nix | sed 's#github:##' | sort -u); do
             info=$(gh api "repos/$repo" --jq '"\(.archived)|\(.pushed_at)"' 2>/dev/null || echo "unknown|unknown")
             archived=${info%%|*}; pushed=${info##*|}
             if [ "$archived" = "true" ]; then
-              echo "- **$repo** — ⚠️ REPOSITORY ARCHIVED (last push $pushed)" >> prompt.md
+              echo "- **$repo** — ⚠️ REPOSITORY ARCHIVED (last push $pushed)" >> findings.md
             elif [ "$archived" = "unknown" ]; then
               # Don't let a failed/rate-limited API call masquerade as "active".
-              echo "- **$repo** — ⚠️ COULD NOT VERIFY (GitHub API error or rate limit)" >> prompt.md
+              echo "- **$repo** — ⚠️ COULD NOT VERIFY (GitHub API error or rate limit)" >> findings.md
             else
-              echo "- $repo — active (last push $pushed)" >> prompt.md
+              echo "- $repo — ✅ active (last push $pushed)" >> findings.md
             fi
           done
 
-          echo "" >> prompt.md
-          echo "## Pinned release binaries (fetchurl)" >> prompt.md
+          echo "" >> findings.md
+          echo "### Pinned release binaries (fetchurl)" >> findings.md
           # Match .../<owner>/<repo>/releases/download/<tag>/... in Nix sources only
           grep -rhoE --include='*.nix' --exclude-dir='.git' 'github\.com/[^/]+/[^/]+/releases/download/[^/]+' . 2>/dev/null \
             | sed -E 's#.*github\.com/([^/]+)/([^/]+)/releases/download/([^/]+).*#\1/\2 \3#' \
             | sort -u | while read -r repo pinned; do
               latest_tag=$(gh api "repos/$repo/releases/latest" --jq '.tag_name' 2>/dev/null || echo "unknown")
               if [ "$latest_tag" != "unknown" ] && [ "$latest_tag" != "$pinned" ]; then
-                echo "- **$repo** — pinned \`$pinned\`, latest release \`$latest_tag\` — ⚠️ BEHIND" >> prompt.md
+                echo "- **$repo** — pinned \`$pinned\`, latest release \`$latest_tag\` — ⚠️ BEHIND" >> findings.md
               else
-                echo "- $repo — pinned \`$pinned\` (latest \`$latest_tag\`)" >> prompt.md
+                echo "- $repo — pinned \`$pinned\` (latest \`$latest_tag\`) — ✅" >> findings.md
               fi
           done
 
-          echo "" >> prompt.md
-          echo "## Other pinned tools (judge by knowledge)" >> prompt.md
+          echo "" >> findings.md
+          echo "### Other pinned tools (supersession — judge by knowledge)" >> findings.md
           nodejs_pins=$(grep -rhoE 'nodejs_[0-9]+' home 2>/dev/null | sort -u | tr '\n' ' ')
-          [ -n "$nodejs_pins" ] && echo "- Pinned Node.js major(s): \`$nodejs_pins\`" >> prompt.md
+          [ -n "$nodejs_pins" ] && echo "- Pinned Node.js major(s): \`$nodejs_pins\`" >> findings.md
 
           # A warning marker (⚠️) anywhere means human attention is needed,
-          # independent of what the model concludes.
-          if grep -q '⚠️' prompt.md; then hard=1; else hard=0; fi
+          # independent of whether the optional Copilot layer runs.
+          if grep -q '⚠️' findings.md; then hard=1; else hard=0; fi
           echo "hard_signal=$hard" >> "$GITHUB_OUTPUT"
-          echo "----- prompt.md -----"; cat prompt.md
 
+          # Wrap findings with instructions for the optional Copilot layer.
+          {
+            echo "# Tool audit input"
+            echo
+            echo "Assess the tools below for DEPRECATION and SUPERSESSION only."
+            echo "The ⚠️ markers are pre-computed and authoritative. Your job:"
+            echo "(1) briefly confirm/explain each ⚠️, and (2) using your own"
+            echo "knowledge, flag any tool SUPERSEDED by a different recommended"
+            echo "tool. Be conservative — do not invent deprecations."
+            echo
+            echo "Reply in GitHub-flavored markdown. The VERY FIRST line must be"
+            echo "exactly 'STATUS: ACTION_NEEDED' or 'STATUS: OK'. Then a short"
+            echo "table (Tool | Source | Finding | Recommendation), then details."
+            echo
+            cat findings.md
+          } > prompt.md
+          echo "----- findings.md -----"; cat findings.md
+
+      # ---- Optional AI layer: skipped without COPILOT_PAT, never fatal --------
       - name: Install GitHub Copilot CLI
+        if: env.HAS_COPILOT_PAT == 'true'
         run: npm install -g @github/copilot
 
       - name: Assess with GitHub Copilot
         id: ai
+        if: env.HAS_COPILOT_PAT == 'true'
+        continue-on-error: true # an inference error must not block issue creation
         uses: actions/ai-inference@v1
         env:
           # A Copilot-enabled token is required — the built-in GITHUB_TOKEN
@@ -133,8 +150,10 @@ jobs:
           model: gpt-4.1
           prompt-file: prompt.md
           max-tokens: 1500
+      # ------------------------------------------------------------------------
 
       - name: Open or update audit issue
+        if: always() # run regardless of the optional AI layer's outcome
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HARD_SIGNAL: ${{ steps.gather.outputs.hard_signal }}
@@ -142,7 +161,20 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -uo pipefail
-          printf '%s\n' "$AI_RESPONSE" > report.md
+
+          # Prefer the Copilot summary; fall back to the deterministic findings
+          # if the AI layer was skipped or failed (empty response).
+          if [ -n "${AI_RESPONSE//[$'\n\t ']/}" ]; then
+            printf '%s\n' "$AI_RESPONSE" > report.md
+          else
+            {
+              echo "## 🔎 Tool freshness audit (deterministic only)"
+              echo
+              echo "_Copilot assessment unavailable (no \`COPILOT_PAT\` or inference error), so this report is the deterministic signals only; supersession was not judged._"
+              echo
+              cat findings.md
+            } > report.md
+          fi
           printf '\n\n---\n_Automated tool audit — [run log](%s)_\n' "$RUN_URL" >> report.md
 
           action_needed=0

--- a/README.md
+++ b/README.md
@@ -428,10 +428,15 @@ Two scheduled workflows keep the repo from going stale:
   `nix flake update` can't detect (e.g. a tool being replaced by a different
   one, as Gemini CLI was by Antigravity CLI). Authoritative signals (npm
   deprecation, GitHub repo archival, release-tag drift) are gathered
-  deterministically; **GitHub Models** (included with Copilot, via
-  `actions/ai-inference` + the built-in `GITHUB_TOKEN` — **no external API key
-  required**) writes the summary and judges supersession. Opens/updates a single
-  issue labeled `tool-audit` when action is needed.
+  deterministically with the built-in `GITHUB_TOKEN`; **GitHub Copilot** (via
+  the Copilot CLI + `actions/ai-inference`) writes the summary and judges
+  supersession. Opens/updates a single issue labeled `tool-audit` when action is
+  needed, and closes it when clean.
+  - **Requires a `COPILOT_PAT` repository secret**: a Personal Access Token from
+    an account with an active **Copilot subscription**. The free GitHub Models
+    endpoint (which needed no secret) was retired 2026-07-30; `actions/ai-inference`
+    now runs on the Copilot CLI, which the built-in `GITHUB_TOKEN` can't
+    authenticate.
 
 #### TODO: broaden update-flake.yml CI validation
 


### PR DESCRIPTION
## Problem

The **Audit Tools** workflow fails: the `Assess with GitHub Models` step returns

```
##[error]410 GitHub Models is temporarily unavailable as part of a scheduled retirement brownout.
```

**GitHub Models was fully retired on 2026-07-30** — the inference API, catalog, and BYOK endpoints are gone. The free, no-secret path we originally chose no longer exists. (See run [31290732149](https://github.com/kourtni/dotfiles/actions/runs/31290732149).)

## Fix — use Copilot directly

`actions/ai-inference` was rewritten to run on the **GitHub Copilot CLI** rather than the dead GitHub Models endpoint, so we can keep an AI step — now backed by your Copilot subscription:

- Install the Copilot CLI (`npm install -g @github/copilot`) before the AI step.
- Authenticate via `COPILOT_GITHUB_TOKEN` from a new **`COPILOT_PAT`** secret (a Copilot-enabled PAT — the built-in `GITHUB_TOKEN` can't authenticate Copilot).
- Pin `model: gpt-4.1` (swap to `claude-sonnet-4.5` if your plan includes it).
- Drop the now-unused `models: read` permission.

The **deterministic signal-gathering** (npm deprecation, repo archival, `fetchurl` release-tag drift) is unchanged and independently drives issue creation, so a hard signal is reported even if the model call is unavailable. Also bumped `setup-node` to 22 (20 is deprecated on runners) and made the workflow auto-close the `tool-audit` issue when a run comes back clean.

## ⚠️ Action required before this works

Add a repository secret **`COPILOT_PAT`** — a (fine-grained) Personal Access Token from an account with an active Copilot subscription. Then trigger **Actions → Audit Tools → Run workflow** to validate. Without the secret, only the AI step fails; the deterministic checks still run.

## Verified

- Root cause confirmed from the failed run logs (HTTP 410) and the GitHub Changelog retirement notice.
- Deterministic gather step confirmed working in that same run (correctly inventoried all npm packages, 7 flake inputs, the `fetchurl` pin, and `nodejs_20`).
- ⚠️ The Copilot CLI + `actions/ai-inference` path is **not yet run end-to-end** here (needs the `COPILOT_PAT` secret) — please validate with a manual dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)