### PR TITLE
fix(nix): replace removed nodejs_20 with nodejs_24 (fixes Update Flake Inputs)

### DIFF
--- a/home/mcp-servers.nix
+++ b/home/mcp-servers.nix
@@ -40,12 +40,12 @@ lib.mkMerge [
         fi
         
         # Run the MCP server
-        exec ${pkgs.nodejs_20}/bin/npx @jpisnice/shadcn-ui-mcp-server "$@"
+        exec ${pkgs.nodejs_24}/bin/npx @jpisnice/shadcn-ui-mcp-server "$@"
       '';
       
       context7McpServerWrapper = pkgs.writeShellScriptBin "context7-mcp-server" ''
         # Run the context7 MCP server
-        exec ${pkgs.nodejs_20}/bin/npx -y @upstash/context7-mcp "$@"
+        exec ${pkgs.nodejs_24}/bin/npx -y @upstash/context7-mcp "$@"
       '';
       
       # Define the mcp-testing-sensei for Linux
@@ -94,7 +94,7 @@ lib.mkMerge [
           ExecStart = "${config.home.profileDirectory}/bin/shadcn-ui-mcp-server";
           Environment = [
             "NPM_CONFIG_PREFIX=%h/.npm-global"
-            "PATH=${pkgs.nodejs_20}/bin:%h/.npm-global/bin:/usr/bin:/bin"
+            "PATH=${pkgs.nodejs_24}/bin:%h/.npm-global/bin:/usr/bin:/bin"
           ];
           Restart = "on-failure";
           RestartSec = "5s";
@@ -122,7 +122,7 @@ lib.mkMerge [
           ExecStart = "${config.home.profileDirectory}/bin/context7-mcp-server";
           Environment = [
             "NPM_CONFIG_PREFIX=%h/.npm-global"
-            "PATH=${pkgs.nodejs_20}/bin:%h/.npm-global/bin:/usr/bin:/bin"
+            "PATH=${pkgs.nodejs_24}/bin:%h/.npm-global/bin:/usr/bin:/bin"
           ];
           Restart = "on-failure";
           RestartSec = "5s";

--- a/home/npm-utils.nix
+++ b/home/npm-utils.nix
@@ -13,7 +13,7 @@
     mkdir -p "$HOME/.npm-global"
     
     # Add Node.js (includes npm), and system tools to PATH for this activation script
-    export PATH="${pkgs.nodejs_20}/bin:${pkgs.gnutar}/bin:${pkgs.gzip}/bin:$PATH"
+    export PATH="${pkgs.nodejs_24}/bin:${pkgs.gnutar}/bin:${pkgs.gzip}/bin:$PATH"
     
     echo "✅ node found: $(which node 2>/dev/null || echo 'node')"
     echo "✅ npm found: $(which npm 2>/dev/null || echo 'npm')"

--- a/home/platforms.nix
+++ b/home/platforms.nix
@@ -76,7 +76,7 @@ in
       fish
       htop
       jq
-      nodejs_20  # LTS version - better binary cache coverage
+      nodejs_24  # LTS version - better binary cache coverage
       # npm is included with nodejs, no need for separate package
       ollama
       opencode   # AI coding agent for the terminal


### PR DESCRIPTION
## Problem

The weekly **Update Flake Inputs** workflow has failed on every run since 2026-07-13 (and the two runs before that for related reasons). Investigating the logs:

| Date | Root cause |
|---|---|
| 2026-06-29 | Transient `HTTP 429` rate-limit fetching `antigravity-nix` during `nix flake update` (one-off) |
| 2026-07-06 | `nodejs_20` (20.20.2) **marked insecure** (EOL 2026-04-30): _"Refusing to evaluate … marked as insecure"_ |
| 2026-07-13 → 2026-08-03 | `nodejs_20` **removed from nixpkgs**: _"Node.js 20 support was removed given upstream End-of-Life"_ |

The workflow runs `nix flake update` (pulling latest `nixos-unstable`) *before* building, so once nixpkgs dropped `nodejs_20`, every subsequent run fails to evaluate the home config.

## Fix

Move all six `pkgs.nodejs_20` references to **`nodejs_24`** (current Active LTS; Node 22 is already in maintenance):

- `home/npm-utils.nix` — activation PATH
- `home/mcp-servers.nix` — 4× (npx wrappers + systemd service PATHs)
- `home/platforms.nix` — the `nodejs_20` package in `home.packages`

## Verified

- `nodejs_24` resolves in the pinned nixpkgs (`24.18.1`).
- The `x86_64-linux` home config evaluates cleanly with the change (`home-manager-generation.drv`).
- Definitive proof will be the next **Update Flake Inputs** run going green (it builds against post-`flake update` nixpkgs, where `nodejs_20` no longer exists).

_Note: this is the "manual review: pinned Node.js major" item the tool-audit workflow was designed to surface — caught here directly from the CI logs._

🤖 Generated with [Claude Code](https://claude.com/claude-code)