### PR TITLE
fix(ci): pin actions/ai-inference to v3 (Copilot-only, fixes 410)

### DIFF
--- a/.github/workflows/audit-tools.yml
+++ b/.github/workflows/audit-tools.yml
@@ -139,7 +139,10 @@ jobs:
         id: ai
         if: env.HAS_COPILOT_PAT == 'true'
         continue-on-error: true # an inference error must not block issue creation
-        uses: actions/ai-inference@v1
+        # v3+ is Copilot-only (shells out to the Copilot CLI installed above).
+        # Do NOT use @v1/@v2 — those still target the retired GitHub Models
+        # endpoint (models.github.ai) and fail with HTTP 410.
+        uses: actions/ai-inference@v3
         env:
           # A Copilot-enabled token is required — the built-in GITHUB_TOKEN
           # does NOT work. Create secret COPILOT_PAT (see header comment).
@@ -149,7 +152,6 @@ jobs:
           # claude-sonnet-4.5 if your Copilot plan includes it.
           model: gpt-4.1
           prompt-file: prompt.md
-          max-tokens: 1500
       # ------------------------------------------------------------------------
 
       - name: Open or update audit issue


### PR DESCRIPTION
## Problem

Even with a valid `COPILOT_PAT`, the **Assess with GitHub Copilot** step still fails with:

```
endpoint: https://models.github.ai/inference
Using legacy prompt format
##[error]410 GitHub Models is temporarily unavailable as part of a scheduled retirement brownout.
```

(See run [31300026317](https://github.com/kourtni/dotfiles/actions/runs/31300026317).)

## Root cause

We pinned `actions/ai-inference@v1`, which is the **2025 release that targets the retired `models.github.ai` endpoint** — so it ignores the Copilot CLI entirely and hits the dead Models API. The Copilot-only backend landed in **v3** (release notes: _"remove github-models support and make copilot the only provider"_), whose `action.yml` has `provider: copilot` and shells out to the Copilot CLI.

> The v3 README example confusingly still shows `@v1` in its snippet — that's what originally led to the wrong pin.

## Fix

- Bump `actions/ai-inference@v1` → `@v3`.
- Drop `max-tokens` (not a v3 input).

Everything else was already correct for v3: the Copilot CLI install step, `COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT }}`, and `model: gpt-4.1`. The resilience wiring (skip without the secret, `continue-on-error`, `if: always()`, deterministic fallback) is unchanged.

## Validation

Please re-run **Actions → Audit Tools → Run workflow** after merge — the Copilot step should now authenticate via the CLI and return an assessment instead of a 410.

🤖 Generated with [Claude Code](https://claude.com/claude-code)