### PR TITLE
chore(ci): bump actions to Node 24 majors (drop Node 20 deprecation)

### DIFF
--- a/.github/workflows/audit-tools.yml
+++ b/.github/workflows/audit-tools.yml
@@ -41,12 +41,12 @@ jobs:
       copilot-requests: write # lets the built-in GITHUB_TOKEN make Copilot requests
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Gather deterministic signals
         id: gather

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -19,10 +19,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v30
+        uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
@@ -105,7 +105,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           # Note: PRs created with GITHUB_TOKEN won't trigger other workflows.
           # Use a PAT or GitHub App token if CI checks are needed on these PRs.


### PR DESCRIPTION
## Why

The workflow logs warn that **Node.js 20 is deprecated**. This is a *different* Node than the one we fixed earlier:

- `nodejs_20 → nodejs_24` (already merged) was the **Nix runtime** for your tools.
- This warning is about the **GitHub Actions runtime** that executes JavaScript actions — several pinned actions are built on the Node 20 runtime, so the runner warns and force-runs them on Node 24.

The fix is to bump those actions to majors built on Node 24.

## Changes (both workflows)

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 (Node 20) | **v7** |
| `actions/setup-node` | v4 (Node 20) | **v7** |
| `cachix/install-nix-action` | v30 | **v31** |
| `peter-evans/create-pull-request` | v7 | **v8** |

Also bumped the Node that `setup-node` **installs** for the audit scripts from 22 → **24**, to match the flake's `nodejs_24`.

## Safety

- `ubuntu-latest` satisfies the newer runner requirement (checkout v5+ needs runner ≥ v2.327.1; hosted runners are well past that).
- Our usage is input-trivial: `checkout` with no inputs, `setup-node` with just `node-version`. Verified `create-pull-request` v8 keeps all inputs we use (`token`, `commit-message`, `title`, `body`, `branch`, `delete-branch`, `labels`, `add-paths`).

## Validation

Re-run **Actions → Audit Tools** after merge — the Node 20 deprecation warnings should be gone. `update-flake.yml` will validate on its next scheduled/dispatch run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)