### PR TITLE
feat(home): export the GitHub MCP token into interactive shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ This repository can also be used to manage Model Context Protocol (MCP) server c
 4. **nixos**: NixOS configuration and package management assistance
 5. **testing-sensei**: Enforces and guides unit testing principles in code generation
 
+**GitHub MCP servers** are not installed by this repository. A GitHub MCP server is declared in the MCP client's own configuration, and each client keeps that configuration somewhere different. The clients installed here (Claude Code, Codex, Antigravity, opencode) all read their own files, so there is no single place this repository could put it.
+
+What this repository does supply is the credential. A server that authenticates with a bearer header resolves `GITHUB_PERSONAL_ACCESS_TOKEN` from its own process environment, and any client launched from a shell inherits the export described in Secrets Management, whichever client it is.
+
 ### Managing MCP Servers
 
 #### On Linux/WSL:
@@ -188,6 +192,7 @@ For NixOS systems, this repository expects a `hardware-configuration.nix` file t
 - **Prompt**: Starship with custom Gruvbox theme
 - **Editor**: Neovim (set as `$EDITOR`)
 - **Aliases**: `ll`, `gs` (git status), `hm-rebuild` (auto-detects system architecture)
+- **GitHub token**: `GITHUB_PERSONAL_ACCESS_TOKEN`, exported from the `github/mcp_token` secret when it is present and readable (see Secrets Management)
 
 ### Development Tools
 
@@ -243,7 +248,23 @@ github:
   name: "Your Name"
   email: "your.email@example.com"
   token: "ghp_your_github_token"
+  mcp_token: "ghp_your_github_mcp_token"
 ```
+
+### GitHub Tokens
+
+The two GitHub tokens are separate secrets with different consumers. Neither is a substitute for the other.
+
+| Secret | Consumed by | Notes |
+|--------|-------------|-------|
+| `github/token` | An activation script writes it to `~/.git-credentials` | Only reached when no other helper claims `github.com` first. If `gh auth setup-git` has run, gh's URL-scoped helper in `~/.gitconfig` takes precedence and this value goes unused. |
+| `github/mcp_token` | Exported as `GITHUB_PERSONAL_ACCESS_TOKEN` in every interactive fish shell | Read by tools following that naming convention: MCP servers that authenticate to GitHub with a bearer header, and the shadcn wrapper, which uses it to lift API rate limits. |
+
+Notes on the exported variable:
+
+- It is set only when the secret exists, is readable, and is non-empty. If any of those fails the variable stays unset, which surfaces as a `401` rather than the `400` an empty bearer token produces.
+- `gh` does not read it. The CLI honors `GH_TOKEN` and `GITHUB_TOKEN`, so exporting this cannot disturb gh's stored credential or git operations that authenticate through gh's helper.
+- Suggested scopes for `mcp_token`: `repo` and `read:org` cover repository, issue, pull request, and Actions **read** access. Add `workflow` only if a tool needs to modify workflow files, remembering that anything running as you can read the variable. Organizations using SAML SSO require the token to be authorized for the organization separately from creating it.
 
 ## 🏠 Host-Specific Customization
 

--- a/home/programs.nix
+++ b/home/programs.nix
@@ -100,6 +100,27 @@ in
         set -gx IS_WSL "$is_wsl"
         set -gx IS_NIXOS "$is_nixos"
       end
+
+      # GitHub PAT for Claude Code's user-level `github` MCP server, which
+      # expands this variable into its Authorization header and resolves it
+      # from its own process environment. The shadcn wrapper in
+      # mcp-servers.nix exports the same secret, but only for itself: an
+      # export inside a script reaches that process and its children, never
+      # the surrounding shell. Setting it session-wide is what lets anything
+      # launched from a shell, Claude Code included, see it.
+      #
+      # Interpolate the secret's path and read it at runtime. Baking the
+      # value in (home.sessionVariables) would place the token in the
+      # world-readable Nix store.
+      if test -r ${config.sops.secrets.github_mcp_token.path}
+        set -l github_mcp_token (cat ${config.sops.secrets.github_mcp_token.path})
+        # Only export a non-empty value. An empty bearer token is worse than
+        # an absent one: GitHub rejects it with 400 "Authorization header is
+        # badly formatted" rather than a 401 that reads as an auth problem.
+        if test -n "$github_mcp_token"
+          set -gx GITHUB_PERSONAL_ACCESS_TOKEN $github_mcp_token
+        end
+      end
     '' + lib.optionalString (vscodePath != null) ''
 
       # Add VS Code CLI to PATH (Platform-specific)

--- a/home/secrets/secrets.yaml.example
+++ b/home/secrets/secrets.yaml.example
@@ -2,3 +2,4 @@ github:
   name: Todd Smith
   email: llcoolj@badas.hell
   token: ghp_yourgithubtokengoeshere
+  mcp_token: ghp_yourgithubmcptokengoeshere


### PR DESCRIPTION
## What

Sets `GITHUB_PERSONAL_ACCESS_TOKEN` session-wide from the existing `github_mcp_token` sops secret, in `programs.fish.shellInit`, and documents the secret that had never been documented.

## Why

An MCP server configured with a bearer token in its header resolves that variable from its own process environment. The shadcn wrapper in `home/mcp-servers.nix` already exports the same secret, but only for itself: an `export` inside a script reaches that process and the children it spawns, never the surrounding shell, and never a sibling process. Setting it at session scope is what lets anything launched from a shell resolve it, whichever MCP client that is.

Verified that this does not disturb other GitHub tooling. `gh` honors `GH_TOKEN` and `GITHUB_TOKEN`, not this variable, so its stored OAuth credential still wins; `git credential fill` continues to hand over the same value it did before.

## Implementation notes

Three deliberate choices, each guarding a failure mode that is quiet rather than loud:

- **Read the secret at runtime rather than via `home.sessionVariables`.** That option bakes values into generated profile scripts in the Nix store, which is world-readable. Interpolating the secret's path and reading it at shell start keeps the token out of the store, matching the pattern the `setupGitSecrets` activation script already uses.
- **Guard on `test -r`, not `test -f`.** These secrets are mode `0400`. A file that exists but cannot be read passes `-f`, then yields an empty value.
- **Refuse to export an empty value.** An empty bearer token is rejected upstream with `400 Authorization header is badly formatted`, which reads as a malformed configuration. An absent variable produces a `401` instead, which correctly points at authentication.

## Documentation

`mcp_token` was missing from both `home/secrets/secrets.yaml.example` and the README's secrets structure, which listed only name, email, and token. Anyone following either produced a secrets file without the key, leaving the shadcn wrapper unauthenticated against GitHub's API rate limits and, after this change, the export inert. Both now include it.

The README also gains a section contrasting the two GitHub secrets: which consumer reads each, why `github/token` can go entirely unused when a URL-scoped credential helper claims `github.com` ahead of the store helper, that `gh` ignores the exported variable, and scope guidance (`repo` plus `read:org` for read access, `workflow` only when a tool must modify workflow files).

One correction worth calling out: GitHub MCP servers are declared by the MCP client, not by this repository, and each installed client keeps that configuration in a different location. The README says so rather than implying a single client.

## Testing

- `nix-instantiate --parse home/programs.nix` parses.
- `nix eval .#nixosConfigurations.wsl.config.home-manager.users.<user>.programs.fish.shellInit` evaluates, and the secret path resolves.
- `fish -n` on the full rendered `shellInit` parses, so a syntax error cannot break shell startup.
- Sourcing the rendered output in a subshell exports the variable when the secret is present, and leaves it unset when it is absent or unreadable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
